### PR TITLE
HU07 list and create client follow up

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+
+pnpm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "build:icons": "tsx src/assets/iconify-icons/bundle-icons-css.ts",
-    "postinstall": "npm run build:icons"
+    "postinstall": "npm run build:icons",
+    "prepare": "husky"
   },
   "dependencies": {
     "@emotion/cache": "^11.14.0",
@@ -49,6 +50,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",
+    "husky": "^9.1.7",
     "postcss": "^8.4.49",
     "postcss-styled-syntax": "^0.7.0",
     "prettier": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       postcss:
         specifier: ^8.4.49
         version: 8.4.49
@@ -1791,6 +1794,11 @@ packages:
 
   htmlparser2@9.1.0:
     resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
@@ -4868,6 +4876,8 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.1.0
       entities: 4.5.0
+
+  husky@9.1.7: {}
 
   hyphenate-style-name@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4466,7 +4466,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4488,7 +4488,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/app/(dashboard)/clients/[id]/follow-up/page.tsx
+++ b/src/app/(dashboard)/clients/[id]/follow-up/page.tsx
@@ -9,6 +9,7 @@ import { Box, Typography, Paper, CircularProgress, TextField, Button, Stack, Gri
 import { useForm, Controller } from 'react-hook-form'
 import { useClient } from '@/hooks/useClient'
 import { useCatalogs } from '@/hooks/useCatalogs'
+import { useFollowUpTypes } from '@/hooks/useFollowUpTypes'
 
 interface FollowUpFormData {
   currentDate: string
@@ -17,6 +18,7 @@ interface FollowUpFormData {
   description: string
   assignedBy: string | number
   assignedTo: string | number
+  gestion: string | number
 }
 
 interface FollowUpRecord extends FollowUpFormData {
@@ -24,6 +26,7 @@ interface FollowUpRecord extends FollowUpFormData {
   createdAt: Date
   assignedByName: string
   assignedToName: string
+  gestionName: string
 }
 
 const ClientFollowUpPage = () => {
@@ -31,6 +34,7 @@ const ClientFollowUpPage = () => {
   const clientId = params.id as string
   const { data: client, isLoading, error } = useClient(clientId)
   const { catalogs, loading: loadingCatalogs } = useCatalogs()
+  const { followUpTypes, loading: loadingFollowUpTypes } = useFollowUpTypes()
   
   // Local state for follow-up records
   const [followUpRecords, setFollowUpRecords] = useState<FollowUpRecord[]>([])
@@ -42,14 +46,16 @@ const ClientFollowUpPage = () => {
       subject: '',
       description: '',
       assignedBy: '',
-      assignedTo: ''
+      assignedTo: '',
+      gestion: ''
     }
   })
 
   const onSubmit = (data: FollowUpFormData) => {
-    // Find agent and executive names
+    // Find agent, executive and gestión names
     const assignedByName = catalogs?.agents.find(agent => agent.id === data.assignedBy)?.name || ''
     const assignedToName = catalogs?.executives.find(executive => executive.id === data.assignedTo)?.name || ''
+    const gestionName = followUpTypes.find(type => type.id === data.gestion)?.name || ''
     
     // Create new follow-up record
     const newRecord: FollowUpRecord = {
@@ -57,7 +63,8 @@ const ClientFollowUpPage = () => {
       id: Date.now().toString(), // Simple ID generation
       createdAt: new Date(),
       assignedByName,
-      assignedToName
+      assignedToName,
+      gestionName
     }
     
     // Add to records list
@@ -70,7 +77,8 @@ const ClientFollowUpPage = () => {
       subject: '',
       description: '',
       assignedBy: '',
-      assignedTo: ''
+      assignedTo: '',
+      gestion: ''
     })
     
     console.log('Seguimiento guardado:', newRecord)
@@ -181,6 +189,9 @@ const ClientFollowUpPage = () => {
                   />
                 </Grid>
 
+                {/* Gestión - Tipo de Seguimiento */}
+                
+
                 <Grid item xs={12}>
                   <Controller
                     name="description"
@@ -203,7 +214,7 @@ const ClientFollowUpPage = () => {
                 </Grid>
 
                 {/* Asignado Por - Agentes */}
-                <Grid item xs={12} md={6}>
+                <Grid item xs={12} md={4}>
                   <Controller
                     name="assignedBy"
                     control={control}
@@ -242,7 +253,7 @@ const ClientFollowUpPage = () => {
                 </Grid>
 
                 {/* Asignado A - Ejecutivos */}
-                <Grid item xs={12} md={6}>
+                <Grid item xs={12} md={4}>
                   <Controller
                     name="assignedTo"
                     control={control}
@@ -273,6 +284,43 @@ const ClientFollowUpPage = () => {
                         {errors.assignedTo && (
                           <Typography variant="caption" color="error" sx={{ mt: 0.5, ml: 1.75 }}>
                             {errors.assignedTo.message}
+                          </Typography>
+                        )}
+                      </FormControl>
+                    )}
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <Controller
+                    name="gestion"
+                    control={control}
+                    rules={{ required: 'El tipo de gestión es requerido' }}
+                    render={({ field }) => (
+                      <FormControl fullWidth error={!!errors.gestion}>
+                        <InputLabel>Tipo de Gestión</InputLabel>
+                        <Select 
+                          {...field} 
+                          label="Tipo de Gestión" 
+                          value={field.value ?? ''} 
+                          disabled={loadingFollowUpTypes}
+                        >
+                          <MenuItem value="">
+                            <em>Seleccionar tipo de gestión</em>
+                          </MenuItem>
+                          {followUpTypes.map(type => (
+                            <MenuItem key={type.id} value={type.id}>
+                              {type.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                        {loadingFollowUpTypes && (
+                          <Typography variant="caption" color="textSecondary">
+                            Cargando tipos de gestión...
+                          </Typography>
+                        )}
+                        {errors.gestion && (
+                          <Typography variant="caption" color="error" sx={{ mt: 0.5, ml: 1.75 }}>
+                            {errors.gestion.message}
                           </Typography>
                         )}
                       </FormControl>
@@ -342,6 +390,12 @@ const ClientFollowUpPage = () => {
                             size="small"
                             variant="outlined"
                             color="secondary"
+                          />
+                          <Chip 
+                            label={`Gestión: ${record.gestionName}`}
+                            size="small"
+                            variant="filled"
+                            color="info"
                           />
                         </Box>
                       </Box>

--- a/src/app/(dashboard)/clients/[id]/follow-up/page.tsx
+++ b/src/app/(dashboard)/clients/[id]/follow-up/page.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import React from 'react'
+
+import { useParams } from 'next/navigation'
+
+import { Box, Typography, Paper, CircularProgress, TextField, Button, Stack, Grid, FormControl, InputLabel, Select, MenuItem } from '@mui/material'
+
+import { useForm, Controller } from 'react-hook-form'
+import { useClient } from '@/hooks/useClient'
+import { useCatalogs } from '@/hooks/useCatalogs'
+
+interface FollowUpFormData {
+  currentDate: string
+  nextFollowUpDate: string
+  subject: string
+  description: string
+  assignedBy: string | number
+  assignedTo: string | number
+}
+
+const ClientFollowUpPage = () => {
+  const params = useParams()
+  const clientId = params.id as string
+  const { data: client, isLoading, error } = useClient(clientId)
+  const { catalogs, loading: loadingCatalogs } = useCatalogs()
+  
+  const { control, handleSubmit, formState: { errors } } = useForm<FollowUpFormData>({
+    defaultValues: {
+      currentDate: new Date().toISOString().split('T')[0], // Today's date in YYYY-MM-DD format
+      nextFollowUpDate: '',
+      subject: '',
+      description: '',
+      assignedBy: '',
+      assignedTo: ''
+    }
+  })
+
+  const onSubmit = (data: FollowUpFormData) => {
+    console.log('Datos del seguimiento:', {
+      ...data,
+      clientId
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: { xs: 2, md: 4 } }}>
+        <Typography variant='h6' color='error'>
+          Error al cargar el cliente
+        </Typography>
+      </Box>
+    )
+  }
+
+  const clientName = client?.person_type === 'N' 
+    ? `${client.first_name || ''} ${client.last_name || ''}`.trim()
+    : client?.first_name || ''
+
+  return (
+    <Box sx={{ p: { xs: 2, md: 4 } }}>
+    <Typography variant='h4' sx={{ mb: 3, fontWeight: 600 }}>
+  Seguimiento del Cliente{' '}
+  <Box
+    component="span"
+    sx={{ color: 'primary.main', fontWeight: 700 }}
+  >
+    {clientName}
+  </Box>
+</Typography>
+
+
+      <Stack spacing={3}>
+        {/* Formulario de Nuevo Seguimiento */}
+        <Paper sx={{ p: 3 }}>
+          <Typography variant='h6' sx={{ mb: 3 }}>
+            Nuevo Seguimiento
+          </Typography>
+          
+          <Box component="form" onSubmit={handleSubmit(onSubmit)}>
+            <Grid container spacing={3}>
+              {/* Fecha Actual - Solo lectura */}
+              <Grid item xs={12} md={6}>
+                <Controller
+                  name="currentDate"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      label="Fecha Actual"
+                      type="date"
+                      fullWidth
+                      InputLabelProps={{ shrink: true }}
+                      disabled
+                      variant="outlined"
+                    />
+                  )}
+                />
+              </Grid>
+
+              {/* Próximo Seguimiento - Editable */}
+              <Grid item xs={12} md={6}>
+                <Controller
+                  name="nextFollowUpDate"
+                  control={control}
+                  rules={{ required: 'La fecha de próximo seguimiento es requerida' }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      label="Próximo Seguimiento"
+                      type="date"
+                      fullWidth
+                      InputLabelProps={{ shrink: true }}
+                      error={!!errors.nextFollowUpDate}
+                      helperText={errors.nextFollowUpDate?.message}
+                      variant="outlined"
+                      inputProps={{
+                        min: new Date().toISOString().split('T')[0] // Minimum date is today
+                      }}
+                    />
+                  )}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                  <Controller
+                    name="subject"
+                    control={control}
+                    rules={{ required: 'El asunto es requerido' }}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        label="Asunto"
+                        fullWidth
+                        variant="outlined"
+                        error={!!errors.subject}
+                        helperText={errors.subject?.message}
+                        placeholder="Describe el asunto del seguimiento..."
+                      />
+                    )}
+                  />
+                </Grid>
+
+                <Grid item xs={12}>
+                  <Controller
+                    name="description"
+                    control={control}
+                    rules={{ required: 'La descripción es requerida' }}
+                    render={({ field }) => (
+                      <TextField
+                        {...field}
+                        label="Descripción"
+                        multiline
+                        rows={4}
+                        fullWidth
+                        variant="outlined"
+                        error={!!errors.description}
+                        helperText={errors.description?.message}
+                        placeholder="Describe el seguimiento..."
+                      />
+                    )}
+                  />
+                </Grid>
+
+                {/* Asignado Por - Agentes */}
+                <Grid item xs={12} md={6}>
+                  <Controller
+                    name="assignedBy"
+                    control={control}
+                    rules={{ required: 'El campo "Asignado por" es requerido' }}
+                    render={({ field }) => (
+                      <FormControl fullWidth error={!!errors.assignedBy}>
+                        <InputLabel>Asignado por (Agente)</InputLabel>
+                        <Select 
+                          {...field} 
+                          label="Asignado por (Agente)" 
+                          value={field.value ?? ''} 
+                          disabled={loadingCatalogs}
+                        >
+                          <MenuItem value="">
+                            <em>Seleccionar agente</em>
+                          </MenuItem>
+                          {catalogs?.agents.map(agent => (
+                            <MenuItem key={agent.id} value={agent.id}>
+                              {agent.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                        {loadingCatalogs && (
+                          <Typography variant="caption" color="textSecondary">
+                            Cargando agentes...
+                          </Typography>
+                        )}
+                        {errors.assignedBy && (
+                          <Typography variant="caption" color="error" sx={{ mt: 0.5, ml: 1.75 }}>
+                            {errors.assignedBy.message}
+                          </Typography>
+                        )}
+                      </FormControl>
+                    )}
+                  />
+                </Grid>
+
+                {/* Asignado A - Ejecutivos */}
+                <Grid item xs={12} md={6}>
+                  <Controller
+                    name="assignedTo"
+                    control={control}
+                    rules={{ required: 'El campo "Asignado a" es requerido' }}
+                    render={({ field }) => (
+                      <FormControl fullWidth error={!!errors.assignedTo}>
+                        <InputLabel>Asignado a (Ejecutivo)</InputLabel>
+                        <Select 
+                          {...field} 
+                          label="Asignado a (Ejecutivo)" 
+                          value={field.value ?? ''} 
+                          disabled={loadingCatalogs}
+                        >
+                          <MenuItem value="">
+                            <em>Seleccionar ejecutivo</em>
+                          </MenuItem>
+                          {catalogs?.executives.map(executive => (
+                            <MenuItem key={executive.id} value={executive.id}>
+                              {executive.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                        {loadingCatalogs && (
+                          <Typography variant="caption" color="textSecondary">
+                            Cargando ejecutivos...
+                          </Typography>
+                        )}
+                        {errors.assignedTo && (
+                          <Typography variant="caption" color="error" sx={{ mt: 0.5, ml: 1.75 }}>
+                            {errors.assignedTo.message}
+                          </Typography>
+                        )}
+                      </FormControl>
+                    )}
+                  />
+                </Grid>
+
+                {/* Botón Guardar */}
+                <Grid item xs={12} container justifyContent="flex-end">
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    size="large"
+                    sx={{ mt: 2 }}
+                  >
+                    Guardar Seguimiento
+                  </Button>
+                </Grid>
+              </Grid>
+            </Box>
+        </Paper>
+
+        {/* Historial de Seguimiento */}
+        <Paper sx={{ p: 3 }}>
+          <Typography variant='h6' sx={{ mb: 2 }}>
+            Historial de Seguimiento
+          </Typography>
+          
+          <Typography variant='body1' color='text.secondary'>
+            Aquí se mostrará el historial de seguimiento del cliente.
+          </Typography>
+        </Paper>
+      </Stack>
+    </Box>
+  )
+}
+
+export default ClientFollowUpPage

--- a/src/app/(dashboard)/clients/[id]/page.tsx
+++ b/src/app/(dashboard)/clients/[id]/page.tsx
@@ -68,7 +68,7 @@ export default function ClientDetailPage() {
 
       try {
         const apiPayload = clientFormToApi(values)
-        
+
         // Debug: Log the payload being sent to API
         console.log('DEBUG: API Payload being sent:', JSON.stringify(apiPayload, null, 2))
 
@@ -90,7 +90,7 @@ export default function ClientDetailPage() {
         }, 2000)
       } catch (err: any) {
         console.error('Error al actualizar cliente:', err)
-        
+
         // Debug: Log detailed error information
         console.log('DEBUG: Error details:', {
           message: err.message,
@@ -99,12 +99,12 @@ export default function ClientDetailPage() {
           stack: err.stack,
           fullError: err
         })
-        
+
         // Try to extract more detailed error information
         if (err.message && err.message.includes('[object Object]')) {
           console.log('DEBUG: Error contains object, trying to parse...')
         }
-        
+
         alert(`DEBUG: Fallo en la actualización: ${err.message}`)
       }
     },
@@ -120,16 +120,15 @@ export default function ClientDetailPage() {
             'Content-Type': 'application/json'
           }
         })
-        
+
         // Mostrar snackbar de eliminación exitosa
         setSuccessMessage('Cliente eliminado con éxito')
         setShowSuccessSnackbar(true)
-        
+
         // Redirigir después de mostrar el snackbar
         setTimeout(() => {
           router.push(ROUTES.CLIENTS.INDEX)
         }, 2000)
-        
       } catch (err: any) {
         // Verificar si el error es un 500 pero la eliminación fue exitosa
         if (err.message && err.message.includes('status: 500')) {

--- a/src/components/clients/steps/BankAccountFields.tsx
+++ b/src/components/clients/steps/BankAccountFields.tsx
@@ -22,11 +22,11 @@ const BankAccountFields = () => {
 
   const handleAddAccount = () => {
     append({
-      bank: '',
+      bank_name: '',
       account_number: '',
       currency: '',
       account_type: '',
-      observations: ''
+      notes: ''
     })
   }
 
@@ -66,7 +66,7 @@ const BankAccountFields = () => {
                     fullWidth
                     label='Banco'
                     placeholder='Nombre del banco'
-                    {...register(`bank_accounts.${index}.bank`)}
+                    {...register(`bank_accounts.${index}.bank_name`)}
                   />
                 </Grid>
                 <Grid item xs={12} md={4}>
@@ -97,7 +97,7 @@ const BankAccountFields = () => {
                   <TextField
                     label='Observaciones'
                     placeholder='Notas adicionales...'
-                    {...register(`bank_accounts.${index}.observations`)}
+                    {...register(`bank_accounts.${index}.notes`)}
                     fullWidth
                   />
                 </Grid>

--- a/src/components/clients/steps/BankAccountFields.tsx
+++ b/src/components/clients/steps/BankAccountFields.tsx
@@ -34,8 +34,7 @@ const BankAccountFields = () => {
     setSavingIndex(index)
 
     try {
-      // Aquí puedes añadir la lógica real para guardar la cuenta bancaria, como llamadas a API
-      await new Promise(resolve => setTimeout(resolve, 1500)) // Simula un retardo
+      await new Promise(resolve => setTimeout(resolve, 1500))
 
     } catch (error) {
 
@@ -46,7 +45,6 @@ const BankAccountFields = () => {
 
   return (
     <Box>
-      {/* Header */}
       <Stack direction='row' justifyContent='space-between' alignItems='center' mb={2}>
         <Typography variant='h6'>Cuentas Bancarias</Typography>
         <Button variant='outlined' startIcon={<Add />} onClick={handleAddAccount}>
@@ -95,7 +93,7 @@ const BankAccountFields = () => {
                     {...register(`bank_accounts.${index}.account_type`)}
                   />
                 </Grid>
-                <Grid item xs={12} md={10}>
+                <Grid item xs={12} md={11}>
                   <TextField
                     label='Observaciones'
                     placeholder='Notas adicionales...'
@@ -104,21 +102,9 @@ const BankAccountFields = () => {
                   />
                 </Grid>
 
-                <Grid item xs={12} md={2}>
+                <Grid item xs={12} md={1}>
                   <Box display='flex' alignItems='center' justifyContent='flex-end' gap={1} height='100%'>
-                    <Button
-                      variant='contained'
-                      onClick={() => handleSaveContact(index)}
-                      startIcon={<Save />}
-                      disabled={savingIndex === index}
-                      sx={{
-                        backgroundColor: '#4caf50',
-                        '&:hover': { backgroundColor: '#45a049' },
-                        minWidth: '120px'
-                      }}
-                    >
-                      {savingIndex === index ? 'Guardando...' : 'Guardar'}
-                    </Button>
+          
                     <IconButton onClick={() => remove(index)} color='error' size='large'>
                       <Delete />
                     </IconButton>

--- a/src/components/clients/steps/BankAccountFields.tsx
+++ b/src/components/clients/steps/BankAccountFields.tsx
@@ -37,7 +37,6 @@ const BankAccountFields = () => {
       await new Promise(resolve => setTimeout(resolve, 1500))
 
     } catch (error) {
-
     } finally {
       setSavingIndex(null)
     }

--- a/src/components/clients/steps/ClientInfoFields.tsx
+++ b/src/components/clients/steps/ClientInfoFields.tsx
@@ -169,7 +169,6 @@ const ClientInfoFields: React.FC<Props> = ({ mode = 'create' }) => {
           />
         </Grid>
 
-        {/* Client Type and Document Number */}
         <Grid item xs={4} sm={2}>
           <Controller
             name='client_type'
@@ -178,13 +177,19 @@ const ClientInfoFields: React.FC<Props> = ({ mode = 'create' }) => {
             rules={{ required: mode === 'create' ? 'El tipo de cliente es requerido' : false }}
             render={({ field }) => (
               <FormControl fullWidth error={!!errors.client_type}>
-                <InputLabel>Tipo Documento</InputLabel>
-                <Select {...field} label='Tipo' value={field.value ?? ''} defaultValue='V'>
-                  <MenuItem value='V'>V</MenuItem>
-                  <MenuItem value='J'>J</MenuItem>
-                  <MenuItem value='E'>E</MenuItem>
-                </Select>
-              </FormControl>
+              <InputLabel id="client-type-label">Tipo Documento</InputLabel>
+              <Select
+                {...field}
+                labelId="client-type-label"
+                label="Tipo Documento"
+                value={field.value ?? ''}
+                defaultValue="V"
+              >
+                <MenuItem value="V">V</MenuItem>
+                <MenuItem value="J">J</MenuItem>
+                <MenuItem value="E">E</MenuItem>
+              </Select>
+            </FormControl>
             )}
           />
         </Grid>

--- a/src/components/clients/steps/ClientInfoFields.tsx
+++ b/src/components/clients/steps/ClientInfoFields.tsx
@@ -188,6 +188,8 @@ const ClientInfoFields: React.FC<Props> = ({ mode = 'create' }) => {
                 <MenuItem value="V">V</MenuItem>
                 <MenuItem value="J">J</MenuItem>
                 <MenuItem value="E">E</MenuItem>
+                <MenuItem value="E">P</MenuItem>
+                <MenuItem value="E">G</MenuItem>
               </Select>
             </FormControl>
             )}

--- a/src/components/clients/steps/ContactListFields.tsx
+++ b/src/components/clients/steps/ContactListFields.tsx
@@ -44,7 +44,6 @@ const ContactListFields = () => {
     }
   }, [clientId, localStorageKey, append, fields.length])
 
-  // Save contacts to localStorage whenever they change
   const saveToLocalStorage = (contacts: any[]) => {
     if (clientId) {
       localStorage.setItem(localStorageKey, JSON.stringify(contacts))
@@ -63,10 +62,8 @@ const ContactListFields = () => {
   }
 
   const handleDeleteContact = (index: number) => {
-    // Remove from form
     remove(index)
     
-    // Update localStorage with remaining contacts
     const formData = getValues()
     
     const remainingContacts = (formData.contacts || []).filter((_, i) => i !== index)
@@ -78,14 +75,9 @@ const ContactListFields = () => {
     
 
   }
-
-
-
-
-
+  
   return (
     <Box>
-      {/* Header con botón */}
       <Stack direction='row' justifyContent='space-between' alignItems='center' mb={2}>
         <Typography variant='h6'>Contactos</Typography>
         <Button variant='outlined' onClick={handleAddContact} startIcon={<Add />}>
@@ -93,7 +85,6 @@ const ContactListFields = () => {
         </Button>
       </Stack>
 
-      {/* Delete Message */}
       {deleteMessage && (
         <Alert severity='info' sx={{ mb: 2 }}>
           {deleteMessage}
@@ -144,7 +135,7 @@ const ContactListFields = () => {
                 />
               </Grid>
 
-              <Grid item xs={12} md={6}>
+              <Grid item xs={12} md={7}>
                 <TextField
                   fullWidth
                   label='Notas'
@@ -152,7 +143,7 @@ const ContactListFields = () => {
                   {...register(`contacts.${index}.notes`)}
                 />
               </Grid>
-              <Grid item xs={12} md={2}>
+              <Grid item xs={12} md={1}>
                 <Box display='flex' alignItems='center' justifyContent='flex-end' gap={1} height='100%'>
                   <IconButton onClick={() => handleDeleteContact(index)} color='error' size='large'>
                     <Delete />

--- a/src/components/clients/steps/ContactListFields.tsx
+++ b/src/components/clients/steps/ContactListFields.tsx
@@ -28,18 +28,15 @@ const ContactListFields = () => {
   useEffect(() => {
     if (clientId) {
       const savedContacts = localStorage.getItem(localStorageKey)
-      
+
       if (savedContacts) {
         try {
-          const contacts = JSON.parse(savedContacts) 
-          
+          const contacts = JSON.parse(savedContacts)
+
           if (contacts.length > 0 && fields.length === 0) {
-          
             contacts.forEach((contact: any) => append(contact))
           }
-        } catch (error) {
-
-        }
+        } catch (error) {}
       }
     }
   }, [clientId, localStorageKey, append, fields.length])
@@ -47,7 +44,6 @@ const ContactListFields = () => {
   const saveToLocalStorage = (contacts: any[]) => {
     if (clientId) {
       localStorage.setItem(localStorageKey, JSON.stringify(contacts))
-
     }
   }
 
@@ -65,15 +61,13 @@ const ContactListFields = () => {
     remove(index)
     
     const formData = getValues()
-    
+
     const remainingContacts = (formData.contacts || []).filter((_, i) => i !== index)
-    
+
     saveToLocalStorage(remainingContacts)
-    
+
     setDeleteMessage('Contacto eliminado')
     setTimeout(() => setDeleteMessage(null), 2000)
-    
-
   }
   
   return (

--- a/src/components/clients/steps/DocumentFields.tsx
+++ b/src/components/clients/steps/DocumentFields.tsx
@@ -99,7 +99,9 @@ const DocumentFields = () => {
                       type='file'
                       accept='.pdf'
                       hidden
-                      ref={(el) => { fileInputRefs.current[index] = el; }}
+                      ref={el => {
+                        fileInputRefs.current[index] = el
+                      }}
                       onChange={e => handleFileChange(e, index)}
                     />
                     <Tooltip title='Subir archivo'>

--- a/src/hooks/useClient.ts
+++ b/src/hooks/useClient.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+import { useApi } from './useApi'
+import { API_ROUTES } from '@/constants/routes'
+import type { Client } from '@/types/client'
+
+export function useClient(id: string) {
+  const [data, setData] = useState<Client | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { fetchApi } = useApi()
+
+  useEffect(() => {
+    if (!id) {
+      setIsLoading(false)
+      
+      return
+    }
+
+    const fetchClient = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        
+        const response = await fetchApi(API_ROUTES.CLIENTS.GET(id))
+        
+        setData(response)
+      } catch (err: any) {
+        setError(err.message || 'Error al cargar el cliente')
+        setData(null)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchClient()
+  }, [id, fetchApi])
+
+  return { data, isLoading, error }
+}

--- a/src/hooks/useClientSearch.ts
+++ b/src/hooks/useClientSearch.ts
@@ -2,15 +2,27 @@ import { useEffect, useState } from 'react'
 
 import type { Client } from '@/types/client'
 
-export function useClientSearch(query: string, enabled: boolean) {
+interface SearchResponse {
+  clients: Client[]
+  total: number
+  page: number
+  per_page: number
+  pages: number
+}
+
+export function useClientSearch(query: string, page: number = 1, perPage: number = 10, enabled: boolean) {
   const [results, setResults] = useState<Client[]>([])
+  const [total, setTotal] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!enabled || !query.trim()) {
       setResults([])
-
+      setTotal(0)
+      setTotalPages(1)
+      
       return
     }
 
@@ -20,15 +32,23 @@ export function useClientSearch(query: string, enabled: boolean) {
     const controller = new AbortController()
     const signal = controller.signal
 
-    fetch(`/api/proxy/clients/search?query=${encodeURIComponent(query)}`, { signal })
+    const searchParams = new URLSearchParams({
+      query: query,
+      page: page.toString(),
+      per_page: perPage.toString()
+    })
+
+    fetch(`/api/proxy/clients/search?${searchParams.toString()}`, { signal })
       .then(async res => {
         if (!res.ok) {
           throw new Error(`Error en la búsqueda: ${res.statusText}`)
         }
 
-        const data = await res.json()
+        const data: SearchResponse = await res.json()
 
         setResults(data.clients || [])
+        setTotal(data.total || 0)
+        setTotalPages(data.pages || 1)
       })
       .catch(err => {
         if (err.name !== 'AbortError') {
@@ -38,7 +58,7 @@ export function useClientSearch(query: string, enabled: boolean) {
       .finally(() => setLoading(false))
 
     return () => controller.abort()
-  }, [query, enabled])
+  }, [query, page, perPage, enabled])
 
-  return { results, loading, error }
+  return { results, total, totalPages, loading, error }
 }

--- a/src/hooks/useFollowUpTypes.ts
+++ b/src/hooks/useFollowUpTypes.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react'
+import { useApi } from './useApi'
+
+interface FollowUpType {
+  id: number
+  name: string
+}
+
+interface UseFollowUpTypesReturn {
+  followUpTypes: FollowUpType[]
+  loading: boolean
+  error: string | null
+}
+
+export const useFollowUpTypes = (): UseFollowUpTypesReturn => {
+  const [followUpTypes, setFollowUpTypes] = useState<FollowUpType[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const { fetchApi } = useApi()
+
+  useEffect(() => {
+    const fetchFollowUpTypes = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const response = await fetchApi('follow-up-types')
+        const data = response.data || response.follow_up_types || response || []
+        setFollowUpTypes(data)
+
+      } catch (err) {
+        setError('Error al cargar los tipos de gestión')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchFollowUpTypes()
+
+  }, [fetchApi])
+
+  return { followUpTypes, loading, error }
+}

--- a/src/types/quotation.ts
+++ b/src/types/quotation.ts
@@ -1,10 +1,10 @@
 export interface Quotation {
-  nroCotizacion: string;
-  fecha: string;
-  cliente: string;
-  ramo: string;
-  aseguradora: string;
-  estado: string;
-  asignadoA: string;
-  estadoGestion: string;
+  nroCotizacion: string
+  fecha: string
+  cliente: string
+  ramo: string
+  aseguradora: string
+  estado: string
+  asignadoA: string
+  estadoGestion: string
 }

--- a/src/views/ClientCreatePage.tsx
+++ b/src/views/ClientCreatePage.tsx
@@ -28,10 +28,8 @@ export default function ClientCreatePage() {
       setSnackbar(prev => ({ ...prev, open: false }))
 
       try {
-
         const apiPayload = clientFormToApi(formData)
-        
-      
+
         await fetchApi(API_ROUTES.CLIENTS.POST, {
           method: 'POST',
           body: apiPayload,
@@ -51,7 +49,7 @@ export default function ClientCreatePage() {
         }, 1500)
       } catch (error: any) {
         console.error('Error creating client:', error)
-        
+
         setSnackbar({
           open: true,
           message: `Error al crear el cliente: ${error.message}`,

--- a/src/views/ClientsPage.tsx
+++ b/src/views/ClientsPage.tsx
@@ -24,15 +24,18 @@ const ClientsPage = () => {
   const apiEnabled = sessionStatus === 'authenticated'
 
   const [search, setSearch] = useState('')
+  const [searchPage, setSearchPage] = useState(1)
 
   const { data: clientsPaginated, loading, error, page, perPage, totalPages, setPage } = useClients(10, apiEnabled)
-  const { results: searchResults, loading: searchLoading, error: searchError } = useClientSearch(search, apiEnabled)
+  const { results: searchResults, totalPages: searchTotalPages, loading: searchLoading, error: searchError } = useClientSearch(search, searchPage, perPage, apiEnabled)
 
   const showingSearch = search.trim().length > 0
   const clientsToShow = showingSearch ? searchResults : clientsPaginated
 
-  // Para búsqueda, paginación local
-  const localTotalPages = showingSearch ? Math.max(1, Math.ceil(searchResults.length / perPage)) : totalPages || 1
+  // Usar las páginas correctas según el contexto
+  const currentTotalPages = showingSearch ? searchTotalPages : totalPages || 1
+  const currentPage = showingSearch ? searchPage : page
+  const currentSetPage = showingSearch ? setSearchPage : setPage
 
   const columns = useMemo(
     () => [
@@ -125,6 +128,7 @@ const ClientsPage = () => {
   const handleSearch = useCallback(
     (query: string) => {
       setSearch(query)
+      setSearchPage(1)
       setPage(1)
     },
     [setPage]
@@ -165,6 +169,7 @@ const ClientsPage = () => {
           onChange={handleSearch}
           onClear={() => {
             setSearch('')
+            setSearchPage(1)
             setPage(1)
           }}
           extraActions={
@@ -183,11 +188,11 @@ const ClientsPage = () => {
           columns={columns}
           rows={clientsToShow}
           emptyMessage={CLIENTS_PAGE.NO_RESULTS}
-          page={page}
-          onPageChange={setPage}
+          page={currentPage}
+          onPageChange={currentSetPage}
           itemsPerPage={perPage}
-          totalPages={localTotalPages}
-          paginateLocally={showingSearch}
+          totalPages={currentTotalPages}
+          paginateLocally={false}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Adds a follow-up module for clients, including a form to create new follow-ups and a table to display previously created follow-ups. That form must works in clients/:id/follow-up route 