### PR TITLE
fix: avoid re render on windows tab focus change

### DIFF
--- a/src/context/sessionContext.tsx
+++ b/src/context/sessionContext.tsx
@@ -4,5 +4,5 @@ import type { ReactNode } from 'react'
 import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
 
 export function SessionProvider({ children }: { children: ReactNode }) {
-  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
+  return <NextAuthSessionProvider refetchOnWindowFocus={false}>{children}</NextAuthSessionProvider>
 }


### PR DESCRIPTION
This pull request makes a small update to the `SessionProvider` component to improve session handling behavior. The change disables automatic session refetching when the browser window regains focus.

- Updated `SessionProvider` in `src/context/sessionContext.tsx` to set `refetchOnWindowFocus={false}` on the `NextAuthSessionProvider`, preventing unnecessary session refetches when the window is focused.