### PR TITLE
Hu11 fix list policies

### DIFF
--- a/src/app/(dashboard)/policies/page.tsx
+++ b/src/app/(dashboard)/policies/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useMemo } from 'react'
+import { useRouter } from 'next/navigation'
 
 import { useSession } from 'next-auth/react'
 
@@ -16,6 +17,7 @@ import { usePolicies } from '@/hooks/usePolicies'
 import { usePolicySearchTypes } from '@/hooks/usePolicySearchTypes'
 
 export default function PoliciesPage() {
+  const router = useRouter()
   const { status: sessionStatus } = useSession()
   const apiEnabled = sessionStatus === 'authenticated'
 
@@ -171,7 +173,7 @@ export default function PoliciesPage() {
           {POLICIES_PAGE.title}
         </Typography>
         <div>
-          <Button variant='contained' color='primary' onClick={() => {}}>
+          <Button variant='contained' color='primary' onClick={() => router.push(ROUTES.POLICIES.CREATE)}>
             {POLICIES_PAGE.createPolicy}
           </Button>
         </div>

--- a/src/app/(dashboard)/policies/page.tsx
+++ b/src/app/(dashboard)/policies/page.tsx
@@ -187,7 +187,6 @@ export default function PoliciesPage() {
           onClear={() => setQuery('')}
           delay={400}
           autoOnChange={false}
-          showSearchButton
           onSearch={handleSearch}
           leadActions={
             <FormControl size='small' sx={{ minWidth: 220 }}>

--- a/src/app/(dashboard)/policies/page.tsx
+++ b/src/app/(dashboard)/policies/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useMemo } from 'react'
+
 import { useRouter } from 'next/navigation'
 
 import { useSession } from 'next-auth/react'


### PR DESCRIPTION
This pull request updates the `PoliciesPage` in the dashboard to improve navigation and streamline the search UI. The most important changes include enabling navigation to the policy creation page and removing the search button from the search component.

**Navigation improvements:**
* Added the `useRouter` hook from Next.js and used it to navigate to the policy creation page when the "Create Policy" button is clicked, replacing the empty handler with `router.push(ROUTES.POLICIES.CREATE)`. [[1]](diffhunk://#diff-89e82996ad0b151fba7238d999c6b589486cbcb5bdc274d647121e4f9f5b1271R5-R6) [[2]](diffhunk://#diff-89e82996ad0b151fba7238d999c6b589486cbcb5bdc274d647121e4f9f5b1271R21) [[3]](diffhunk://#diff-89e82996ad0b151fba7238d999c6b589486cbcb5bdc274d647121e4f9f5b1271L174-R177)

**UI simplification:**
* Removed the `showSearchButton` prop from the search component, streamlining the search UI.