### PR TITLE
Hu11 vehicles form

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "build:icons": "tsx src/assets/iconify-icons/bundle-icons-css.ts",
     "postinstall": "npm run build:icons",
@@ -43,6 +43,7 @@
     "server-only": "^0.0.1"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@iconify/json": "^2.2.288",
     "@iconify/tools": "^4.1.1",
     "@iconify/types": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@iconify/json':
         specifier: ^2.2.288
         version: 2.2.385
@@ -499,6 +502,10 @@ packages:
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
@@ -2024,11 +2031,19 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -2223,6 +2238,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
@@ -4033,6 +4052,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
 
   '@floating-ui/core@1.7.3':
@@ -5669,6 +5702,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint@8.57.1:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
@@ -5711,6 +5746,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -5924,6 +5965,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
 
   globals@15.15.0: {}
 

--- a/src/app/(dashboard)/policies/create/components/VehicleModal.tsx
+++ b/src/app/(dashboard)/policies/create/components/VehicleModal.tsx
@@ -53,6 +53,7 @@ interface VehicleApiPayload {
   circulation_city_id: number
   color: string
   has_gps: boolean
+  [key: string]: unknown
 }
 
 interface VehicleModalProps {
@@ -102,40 +103,6 @@ const getColorCode = (colorName: string): string => {
 }
 
 const convertToApiPayload = (formData: VehicleFormData): VehicleApiPayload => {
-  const errors: string[] = []
-
-  if (!formData.license_plate?.trim()) {
-    errors.push('La placa es requerida')
-  }
-
-  if (!formData.brand_id) {
-    errors.push('La marca es requerida')
-  }
-
-  if (!formData.model_id) {
-    errors.push('El modelo es requerido')
-  }
-
-  if (!formData.version_id) {
-    errors.push('La versión es requerida')
-  }
-
-  if (!formData.year || formData.year < 1900) {
-    errors.push('El año debe ser mayor o igual a 1900')
-  }
-
-  if (!formData.circulation_city_id) {
-    errors.push('El lugar de circulación es requerido')
-  }
-
-  if (!formData.color?.trim()) {
-    errors.push('El color es requerido')
-  }
-
-  if (errors.length > 0) {
-    throw new Error(errors.join(', '))
-  }
-
   return {
     license_plate: formData.license_plate.trim().toUpperCase(),
     brand_id: formData.brand_id!,
@@ -210,19 +177,12 @@ const VehicleModal = ({ open, onClose, onSuccess }: VehicleModalProps) => {
 
       const apiPayload = convertToApiPayload(data)
 
-      console.log('Vehicle API payload:', apiPayload)
-
-      const response = await fetchApi<any>('vehicles', {
+      await fetchApi('vehicles', {
         method: 'POST',
-        body: apiPayload,
-        headers: {
-          'Content-Type': 'application/json'
-        }
+        body: apiPayload
       })
 
-      console.log('Vehicle created successfully:', response)
       showSuccess('Vehículo creado exitosamente')
-
       reset()
 
       if (onSuccess) {
@@ -231,17 +191,10 @@ const VehicleModal = ({ open, onClose, onSuccess }: VehicleModalProps) => {
 
       onClose()
     } catch (err: any) {
-      console.error('Error creating vehicle:', err)
-      console.error('Full error object:', JSON.stringify(err, null, 2))
+      const errorMessage =
+        err?.message || 'Error al crear el vehículo. Por favor, verifica los datos e intenta nuevamente.'
 
-      if (err?.response?.data) {
-        console.error('API Error Response:', err.response.data)
-        showError(`Error al crear el vehículo: ${JSON.stringify(err.response.data)}`)
-      } else if (err?.message) {
-        showError(`Error al crear el vehículo: ${err.message}`)
-      } else {
-        showError('Error al crear el vehículo. Por favor, verifica los datos e intenta nuevamente.')
-      }
+      showError(errorMessage)
     } finally {
       setIsSubmitting(false)
     }

--- a/src/app/(dashboard)/policies/create/components/VehicleModal.tsx
+++ b/src/app/(dashboard)/policies/create/components/VehicleModal.tsx
@@ -30,6 +30,7 @@ import { useModels } from '@/app/(dashboard)/vehicles/hooks/useModels'
 import { useVersions } from '@/app/(dashboard)/vehicles/hooks/useVersions'
 
 import { useSnackbar } from '@/hooks/useSnackbar'
+import { useCatalogs, type CatalogsResponse } from '@/hooks/useCatalogs'
 
 interface VehicleFormData {
   license_plate: string
@@ -93,6 +94,8 @@ const VehicleModal = ({ open, onClose, onSuccess }: VehicleModalProps) => {
   const { data: brands, loading: brandsLoading, error: brandsError, setParams: setBrandParams } = useBrands()
   const { data: models, loading: modelsLoading, error: modelsError, setParams: setModelParams } = useModels()
   const { data: versions, loading: versionsLoading, error: versionsError, setParams: setVersionParams } = useVersions()
+
+  const { catalogs, loading: catalogsLoading, error: catalogsError } = useCatalogs()
 
   const { showSuccess, showError } = useSnackbar()
 
@@ -434,15 +437,29 @@ const VehicleModal = ({ open, onClose, onSuccess }: VehicleModalProps) => {
                 render={({ field }) => (
                   <FormControl fullWidth error={!!errors.circulation_city_id}>
                     <InputLabel>Lugar de Circulación</InputLabel>
-                    <Select {...field} label='Lugar de Circulación' value={field.value ?? ''}>
+                    <Select
+                      {...field}
+                      label='Lugar de Circulación'
+                      value={field.value ?? ''}
+                      disabled={catalogsLoading}
+                    >
                       <MenuItem value=''>
                         <em>Seleccionar ciudad</em>
                       </MenuItem>
-                      {/* TODO: Cargar ciudades desde la API */}
+                      {catalogs?.cities?.map((city: CatalogsResponse['cities'][0]) => (
+                        <MenuItem key={city.id} value={city.id}>
+                          {city.name}
+                        </MenuItem>
+                      ))}
                     </Select>
                     {errors.circulation_city_id && (
                       <Typography variant='caption' color='error' sx={{ mt: 0.5, ml: 1.75 }}>
                         {errors.circulation_city_id.message}
+                      </Typography>
+                    )}
+                    {catalogsError && (
+                      <Typography variant='caption' color='error' sx={{ mt: 0.5, ml: 1.75 }}>
+                        {catalogsError}
                       </Typography>
                     )}
                   </FormControl>

--- a/src/app/(dashboard)/policies/create/page.tsx
+++ b/src/app/(dashboard)/policies/create/page.tsx
@@ -110,7 +110,7 @@ export default function PolicyForm() {
     setIsVehicleModalOpen(false)
   }
 
-  const handleVehicleCreated = (vehicleData: any) => {
+  const handleVehicleCreated = () => {
     showSuccess('Vehículo creado exitosamente')
   }
 

--- a/src/app/(dashboard)/policies/create/page.tsx
+++ b/src/app/(dashboard)/policies/create/page.tsx
@@ -111,9 +111,6 @@ export default function PolicyForm() {
   }
 
   const handleVehicleCreated = (vehicleData: any) => {
-    // TODO: Cuando se conecte a la API, aquí se actualizará el autocomplete de vehículos
-    // y se seleccionará el vehículo recién creado
-    console.log('Vehicle created:', vehicleData)
     showSuccess('Vehículo creado exitosamente')
   }
 
@@ -326,7 +323,7 @@ export default function PolicyForm() {
                 render={({ field, fieldState }) => (
                   <FormControl fullWidth error={!!fieldState.error}>
                     <InputLabel>Compañía</InputLabel>
-                    <Select {...field} label='Compañía' disabled={companiesLoading}>
+                    <Select {...field} label='Compañía' value={field.value ?? ''} disabled={companiesLoading}>
                       {insuranceCompanies.map(company => (
                         <MenuItem key={company.id} value={company.id}>
                           {company.name}
@@ -355,7 +352,7 @@ export default function PolicyForm() {
                 render={({ field, fieldState }) => (
                   <FormControl fullWidth error={!!fieldState.error}>
                     <InputLabel>Ramo</InputLabel>
-                    <Select {...field} label='Ramo' disabled={linesLoading}>
+                    <Select {...field} label='Ramo' value={field.value ?? ''} disabled={linesLoading}>
                       {insuranceLines.map(line => (
                         <MenuItem key={line.id} value={line.id}>
                           {line.name}
@@ -486,7 +483,7 @@ export default function PolicyForm() {
                 render={({ field }) => (
                   <FormControl fullWidth>
                     <InputLabel>Período</InputLabel>
-                    <Select {...field} label='Período'>
+                    <Select {...field} label='Período' value={field.value ?? ''}>
                       {POLICY_PERIOD_OPTIONS.map(opt => (
                         <MenuItem key={opt.value} value={opt.value}>
                           {opt.label}
@@ -505,7 +502,7 @@ export default function PolicyForm() {
                 render={({ field }) => (
                   <FormControl fullWidth>
                     <InputLabel>Modo de Pago</InputLabel>
-                    <Select {...field} label='Modo de Pago'>
+                    <Select {...field} label='Modo de Pago' value={field.value ?? ''}>
                       {PAYMENT_MODE_OPTIONS.map(opt => (
                         <MenuItem key={opt.value} value={opt.value}>
                           {opt.label}
@@ -524,7 +521,7 @@ export default function PolicyForm() {
                 render={({ field, fieldState }) => (
                   <FormControl fullWidth error={!!fieldState.error}>
                     <InputLabel>Cobrador</InputLabel>
-                    <Select {...field} label='Cobrador' disabled={collectorsLoading}>
+                    <Select {...field} label='Cobrador' value={field.value ?? ''} disabled={collectorsLoading}>
                       {collectors.map(collector => (
                         <MenuItem key={collector.id} value={collector.id}>
                           {collector.name}

--- a/src/app/(dashboard)/vehicles/hooks/useBrands.ts
+++ b/src/app/(dashboard)/vehicles/hooks/useBrands.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback } from 'react'
+
+import { useApi } from '@/hooks/useApi'
+
+export interface Brand {
+  id: number
+  name: string
+  code: string
+}
+
+interface BrandsApiResponse {
+  success: boolean
+  brands: Brand[]
+  total?: number
+  pages?: number
+  page?: number
+  per_page?: number
+}
+
+export function useBrands() {
+  const { fetchApi } = useApi()
+  const [brands, setBrands] = useState<Brand[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [params, setParams] = useState<{ q?: string }>({})
+
+  const fetchAllBrands = useCallback(
+    async (currentParams: { q?: string }) => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        let allBrands: Brand[] = []
+        let currentPage = 1
+        let hasMorePages = true
+
+        while (hasMorePages) {
+          const searchParams = new URLSearchParams()
+
+          searchParams.set('page', String(currentPage))
+          searchParams.set('perPage', '100')
+
+          if (currentParams.q) {
+            searchParams.set('q', currentParams.q)
+          }
+
+          const url = `vehicles/brands?${searchParams.toString()}`
+          const response = await fetchApi<BrandsApiResponse>(url)
+
+          if (response && response.brands) {
+            allBrands = [...allBrands, ...response.brands]
+
+            // Verificar si hay más páginas
+            if (response.pages && currentPage >= response.pages) {
+              hasMorePages = false
+            } else if (response.brands.length < 100) {
+              // Si recibimos menos de 100, probablemente es la última página
+              hasMorePages = false
+            } else {
+              currentPage++
+            }
+          } else {
+            hasMorePages = false
+          }
+        }
+
+        setBrands(allBrands)
+      } catch (err: any) {
+        setError(err.message || 'Error al cargar las marcas.')
+        setBrands([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [fetchApi]
+  )
+
+  useEffect(() => {
+    fetchAllBrands(params)
+  }, [params, fetchAllBrands])
+
+  return {
+    data: brands,
+    loading,
+    error,
+    setParams
+  }
+}

--- a/src/app/(dashboard)/vehicles/hooks/useModels.ts
+++ b/src/app/(dashboard)/vehicles/hooks/useModels.ts
@@ -2,35 +2,35 @@ import { useState, useEffect, useCallback } from 'react'
 
 import { useApi } from '@/hooks/useApi'
 
-export interface Brand {
+export interface Model {
   id: number
   name: string
   code: string
 }
 
-interface BrandsApiResponse {
+interface ModelsApiResponse {
   success: boolean
-  brands: Brand[]
+  models: Model[]
   total?: number
   pages?: number
   page?: number
   per_page?: number
 }
 
-export function useBrands() {
+export function useModels() {
   const { fetchApi } = useApi()
-  const [brands, setBrands] = useState<Brand[]>([])
+  const [models, setModels] = useState<Model[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [params, setParams] = useState<{ q?: string }>({})
+  const [params, setParams] = useState<{ q?: string; brand_id?: number }>({})
 
-  const fetchAllBrands = useCallback(
-    async (currentParams: { q?: string }) => {
+  const fetchAllModels = useCallback(
+    async (currentParams: { q?: string; brand_id?: number }) => {
       setLoading(true)
       setError(null)
 
       try {
-        let allBrands: Brand[] = []
+        let allModels: Model[] = []
         let currentPage = 1
         let hasMorePages = true
 
@@ -44,15 +44,19 @@ export function useBrands() {
             searchParams.set('q', currentParams.q)
           }
 
-          const url = `vehicles/brands?${searchParams.toString()}`
-          const response = await fetchApi<BrandsApiResponse>(url)
+          if (currentParams.brand_id) {
+            searchParams.set('brand_id', String(currentParams.brand_id))
+          }
 
-          if (response && response.brands) {
-            allBrands = [...allBrands, ...response.brands]
+          const url = `vehicles/models?${searchParams.toString()}`
+          const response = await fetchApi<ModelsApiResponse>(url)
+
+          if (response && response.models) {
+            allModels = [...allModels, ...response.models]
 
             if (response.pages && currentPage >= response.pages) {
               hasMorePages = false
-            } else if (response.brands.length < 100) {
+            } else if (response.models.length < 100) {
               hasMorePages = false
             } else {
               currentPage++
@@ -62,10 +66,10 @@ export function useBrands() {
           }
         }
 
-        setBrands(allBrands)
+        setModels(allModels)
       } catch (err: any) {
-        setError(err.message || 'Error al cargar las marcas.')
-        setBrands([])
+        setError(err.message || 'Error al cargar los modelos.')
+        setModels([])
       } finally {
         setLoading(false)
       }
@@ -74,11 +78,11 @@ export function useBrands() {
   )
 
   useEffect(() => {
-    fetchAllBrands(params)
-  }, [params, fetchAllBrands])
+    fetchAllModels(params)
+  }, [params, fetchAllModels])
 
   return {
-    data: brands,
+    data: models,
     loading,
     error,
     setParams

--- a/src/app/(dashboard)/vehicles/hooks/useVersions.ts
+++ b/src/app/(dashboard)/vehicles/hooks/useVersions.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback } from 'react'
+
+import { useApi } from '@/hooks/useApi'
+
+export interface Model {
+  id: number
+  name: string
+  code: string
+}
+
+interface VersionsApiResponse {
+  success: boolean
+  versions: Model[]
+  total?: number
+  pages?: number
+  page?: number
+  per_page?: number
+}
+
+export function useVersions() {
+  const { fetchApi } = useApi()
+  const [versions, setVersions] = useState<Model[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [params, setParams] = useState<{ q?: string; model_id?: number }>({})
+
+  const fetchAllVersions = useCallback(
+    async (currentParams: { q?: string; model_id?: number }) => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        let allVersions: Model[] = []
+        let currentPage = 1
+        let hasMorePages = true
+
+        while (hasMorePages) {
+          const searchParams = new URLSearchParams()
+
+          searchParams.set('page', String(currentPage))
+          searchParams.set('perPage', '100')
+
+          if (currentParams.q) {
+            searchParams.set('q', currentParams.q)
+          }
+
+          if (currentParams.model_id) {
+            searchParams.set('model_id', String(currentParams.model_id))
+          }
+
+          const url = `vehicles/versions?${searchParams.toString()}`
+          const response = await fetchApi<VersionsApiResponse>(url)
+
+          if (response && response.versions) {
+            allVersions = [...allVersions, ...response.versions]
+
+            if (response.pages && currentPage >= response.pages) {
+              hasMorePages = false
+            } else if (response.versions.length < 100) {
+              hasMorePages = false
+            } else {
+              currentPage++
+            }
+          } else {
+            hasMorePages = false
+          }
+        }
+
+        setVersions(allVersions)
+      } catch (err: any) {
+        setError(err.message || 'Error al cargar las versiones.')
+        setVersions([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [fetchApi]
+  )
+
+  useEffect(() => {
+    fetchAllVersions(params)
+  }, [params, fetchAllVersions])
+
+  return {
+    data: versions,
+    loading,
+    error,
+    setParams
+  }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the vehicle creation modal, enhancing both user experience and backend integration. The main changes include switching brand/model/version selectors from static dropdowns to dynamic autocompletes that fetch data from APIs, updating validation rules, and refactoring form payload handling. Additionally, some tooling updates were made to the linting scripts and dependencies.

**Vehicle Modal Functional Improvements**
* Replaced static dropdowns for `brand_id`, `model_id`, and `version_id` with dynamic `Autocomplete` components that fetch and filter options from APIs, including loading states, error handling, and dependent selection logic. [[1]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfL241-R341) [[2]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfL266-R385) [[3]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfL291-R429)
* Updated form validation logic for fields such as `color` (minimum length), and expanded valid year range from 1940 to 1900 for vehicle manufacturing year. [[1]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfL191-R264) [[2]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfL316-R441)
* Refactored form data types to use `number` for IDs and added a conversion step to ensure the API payload matches backend requirements. [[1]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfR28-R56) [[2]](diffhunk://#diff-25be03c64555be4adc69f59c825709ea739e0ade0731d46d316f252a88cabbdfR105-R185)
* Improved error messaging during vehicle creation to display API error messages when available.

**Tooling and Dependency Updates**
* Updated linting scripts in `package.json` to use `eslint` directly instead of `next lint`, and added `@eslint/eslintrc` as a development dependency. Corresponding lockfile updates were made for new dependencies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R11) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R46) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR93-R95) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR506-R509) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2034-R2047) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2242-R2245) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4055-R4068) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5705-R5706) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5750-R5755) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5969-R5970)