### PR TITLE
Hu11 co insurance

### DIFF
--- a/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
+++ b/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
@@ -52,7 +52,7 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
   const handleCalculate = () => {
     const newEntry: CoInsuranceEntry = {
       insurance_company_id: null,
-      percentage: '0.00',
+      percentage: '0',
       sum_insured: sumInsured || '0.00',
       retention_percentage: '0.00',
       premium: premium || '0.00',
@@ -76,7 +76,7 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
   const handleAddInsurer = () => {
     const newEntry: CoInsuranceEntry = {
       insurance_company_id: null,
-      percentage: '0.00',
+      percentage: '0',
       sum_insured: '0.00',
       retention_percentage: '0.00',
       premium: '0.00',
@@ -114,6 +114,20 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
       ...updatedEntries[index],
       [field]: value
     }
+
+    if (field === 'percentage' && typeof value === 'string') {
+      const percentageInput = parseFloat(value) || 0
+
+      const percentage = percentageInput / 100
+      const totalSumInsured = parseFloat(sumInsured) || 0
+      const totalPremium = parseFloat(premium) || 0
+      const totalCommission = parseFloat(commission) || 0
+
+      updatedEntries[index].sum_insured = (totalSumInsured * percentage).toFixed(2)
+      updatedEntries[index].premium = (totalPremium * percentage).toFixed(2)
+      updatedEntries[index].commission = (totalCommission * percentage).toFixed(2)
+    }
+
     setEntries(updatedEntries)
 
     if (onEntriesChange) {
@@ -262,13 +276,24 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                       value={entry.percentage}
                       onChange={e => handleFieldChange(index, 'percentage', e.target.value)}
                       size='small'
-                      inputProps={{ step: '0.01', min: '0', max: '1' }}
+                      inputProps={{ step: '0.01', min: '0', max: '100' }}
                       sx={{
                         width: '100%',
                         '& .MuiInputBase-input': {
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />
@@ -286,6 +311,17 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />
@@ -296,13 +332,24 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                       value={entry.retention_percentage}
                       onChange={e => handleFieldChange(index, 'retention_percentage', e.target.value)}
                       size='small'
-                      inputProps={{ step: '0.01', min: '0', max: '1' }}
+                      inputProps={{ step: '0.01', min: '0', max: '100' }}
                       sx={{
                         width: '100%',
                         '& .MuiInputBase-input': {
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />
@@ -320,6 +367,17 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />
@@ -337,6 +395,17 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />
@@ -354,6 +423,17 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
                           fontSize: '0.75rem',
                           p: '4px 8px',
                           textAlign: 'right'
+                        },
+                        '& input[type=number]': {
+                          '-moz-appearance': 'textfield'
+                        },
+                        '& input[type=number]::-webkit-outer-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
+                        },
+                        '& input[type=number]::-webkit-inner-spin-button': {
+                          '-webkit-appearance': 'none',
+                          margin: 0
                         }
                       }}
                     />

--- a/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
+++ b/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
@@ -203,48 +203,46 @@ const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTa
           sx={{
             maxHeight: 'calc(100vh - 450px)',
             overflowY: 'auto',
-            overflowX: 'auto'
+            overflowX: 'hidden'
           }}
         >
-          <Table size='small' stickyHeader>
+          <Table size='small' stickyHeader sx={{ tableLayout: 'fixed', width: '100%' }}>
             <TableHead>
               <TableRow>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 150, p: 1 }}>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '12%', p: 0.5, fontSize: '0.7rem' }}>
                   Aseguradoras
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
-                  % CoAseguro
+                <TableCell align='center' sx={{ fontWeight: 600, width: '7%', p: 0.5, fontSize: '0.7rem' }}>
+                  % CoAseg.
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 120, p: 1 }}>
-                  Suma Asegurada
+                <TableCell align='center' sx={{ fontWeight: 600, width: '9%', p: 0.5, fontSize: '0.7rem' }}>
+                  S. Asegurada
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
-                  % Retención
+                <TableCell align='center' sx={{ fontWeight: 600, width: '7%', p: 0.5, fontSize: '0.7rem' }}>
+                  % Retenc.
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '8%', p: 0.5, fontSize: '0.7rem' }}>
                   Prima
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '8%', p: 0.5, fontSize: '0.7rem' }}>
                   Comisión
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '7%', p: 0.5, fontSize: '0.7rem' }}>
                   Bono
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 120, p: 1 }}>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '8%', p: 0.5, fontSize: '0.7rem' }}>
                   Recibo
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 130, p: 1 }}>
-                  F.Pago Prima
+                <TableCell align='center' sx={{ fontWeight: 600, width: '10%', p: 0.5, fontSize: '0.7rem' }}>
+                  F.P. Prima
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 150, p: 1 }}>
-                  F.Pago Comisión
+                <TableCell align='center' sx={{ fontWeight: 600, width: '10%', p: 0.5, fontSize: '0.7rem' }}>
+                  F.P. Comis.
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 130, p: 1 }}>
-                  F.Pago Bono
+                <TableCell align='center' sx={{ fontWeight: 600, width: '10%', p: 0.5, fontSize: '0.7rem' }}>
+                  F.P. Bono
                 </TableCell>
-                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 80, p: 1 }}>
-                  Acciones
-                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, width: '4%', p: 0.5, fontSize: '0.7rem' }}></TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
+++ b/src/app/(dashboard)/policies/create/components/CoInsuranceTable.tsx
@@ -1,0 +1,453 @@
+'use client'
+
+import React, { useState } from 'react'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  Box,
+  Select,
+  MenuItem,
+  FormControl,
+  IconButton,
+  Tooltip
+} from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+interface CoInsuranceEntry {
+  insurance_company_id: number | null
+  percentage: string
+  sum_insured: string
+  retention_percentage: string
+  premium: string
+  commission: string
+  bonus: string
+  receipt_number: string
+  premium_payment_date: string
+  commission_payment_date: string | null
+  bonus_payment_date: string | null
+}
+
+interface CoInsuranceTableProps {
+  insuranceCompanies: Array<{ id: number; name: string }>
+  onEntriesChange?: (entries: CoInsuranceEntry[]) => void
+}
+
+const CoInsuranceTable = ({ insuranceCompanies, onEntriesChange }: CoInsuranceTableProps) => {
+  const [sumInsured, setSumInsured] = useState<string>('')
+  const [premium, setPremium] = useState<string>('')
+  const [commission, setCommission] = useState<string>('')
+  const [entries, setEntries] = useState<CoInsuranceEntry[]>([])
+
+  const handleCalculate = () => {
+    const newEntry: CoInsuranceEntry = {
+      insurance_company_id: null,
+      percentage: '0.00',
+      sum_insured: sumInsured || '0.00',
+      retention_percentage: '0.00',
+      premium: premium || '0.00',
+      commission: commission || '0.00',
+      bonus: '0.00',
+      receipt_number: '',
+      premium_payment_date: '',
+      commission_payment_date: null,
+      bonus_payment_date: null
+    }
+
+    const newEntries = [newEntry]
+
+    setEntries(newEntries)
+
+    if (onEntriesChange) {
+      onEntriesChange(newEntries)
+    }
+  }
+
+  const handleAddInsurer = () => {
+    const newEntry: CoInsuranceEntry = {
+      insurance_company_id: null,
+      percentage: '0.00',
+      sum_insured: '0.00',
+      retention_percentage: '0.00',
+      premium: '0.00',
+      commission: '0.00',
+      bonus: '0.00',
+      receipt_number: '',
+      premium_payment_date: '',
+      commission_payment_date: null,
+      bonus_payment_date: null
+    }
+
+    const updatedEntries = [...entries, newEntry]
+
+    setEntries(updatedEntries)
+
+    if (onEntriesChange) {
+      onEntriesChange(updatedEntries)
+    }
+  }
+
+  const handleDeleteInsurer = (index: number) => {
+    const updatedEntries = entries.filter((_, i) => i !== index)
+
+    setEntries(updatedEntries)
+
+    if (onEntriesChange) {
+      onEntriesChange(updatedEntries)
+    }
+  }
+
+  const handleFieldChange = (index: number, field: keyof CoInsuranceEntry, value: string | number | null) => {
+    const updatedEntries = [...entries]
+
+    updatedEntries[index] = {
+      ...updatedEntries[index],
+      [field]: value
+    }
+    setEntries(updatedEntries)
+
+    if (onEntriesChange) {
+      onEntriesChange(updatedEntries)
+    }
+  }
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Typography variant='h6' sx={{ mb: 2, fontWeight: 600 }}>
+        Control de Póliza con Coaseguro
+      </Typography>
+
+      {/* Inputs de control */}
+      <Paper sx={{ p: 3, mb: 3 }} variant='outlined'>
+        <Grid container spacing={2} alignItems='center'>
+          <Grid item xs={12} md={3}>
+            <TextField
+              label='Suma Asegurada'
+              type='number'
+              value={sumInsured}
+              onChange={e => setSumInsured(e.target.value)}
+              fullWidth
+              size='small'
+              inputProps={{ step: '0.01', min: '0' }}
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <TextField
+              label='Prima'
+              type='number'
+              value={premium}
+              onChange={e => setPremium(e.target.value)}
+              fullWidth
+              size='small'
+              inputProps={{ step: '0.01', min: '0' }}
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <TextField
+              label='Comisión'
+              type='number'
+              value={commission}
+              onChange={e => setCommission(e.target.value)}
+              fullWidth
+              size='small'
+              inputProps={{ step: '0.01', min: '0' }}
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <Button variant='outlined' onClick={handleCalculate} fullWidth>
+              Calcular
+            </Button>
+          </Grid>
+        </Grid>
+      </Paper>
+
+      {/* Tabla de coaseguro */}
+      {entries.length === 0 ? (
+        <Paper sx={{ p: 4 }} variant='outlined'>
+          <Typography variant='body1' align='center' sx={{ color: 'text.secondary' }}>
+            Los resultados del cálculo aparecerán aquí
+            <br />
+            <Typography variant='body2' sx={{ mt: 1 }}>
+              Complete los campos y presione &quot;Calcular&quot;
+            </Typography>
+          </Typography>
+        </Paper>
+      ) : (
+        <TableContainer
+          component={Paper}
+          variant='outlined'
+          sx={{
+            maxHeight: 'calc(100vh - 450px)',
+            overflowY: 'auto',
+            overflowX: 'auto'
+          }}
+        >
+          <Table size='small' stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 150, p: 1 }}>
+                  Aseguradoras
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                  % CoAseguro
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 120, p: 1 }}>
+                  Suma Asegurada
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                  % Retención
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                  Prima
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                  Comisión
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 100, p: 1 }}>
+                  Bono
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 120, p: 1 }}>
+                  Recibo
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 130, p: 1 }}>
+                  F.Pago Prima
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 150, p: 1 }}>
+                  F.Pago Comisión
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 130, p: 1 }}>
+                  F.Pago Bono
+                </TableCell>
+                <TableCell align='center' sx={{ fontWeight: 600, minWidth: 80, p: 1 }}>
+                  Acciones
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {entries.map((entry, index) => (
+                <TableRow key={index} hover>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <FormControl fullWidth size='small'>
+                      <Select
+                        value={entry.insurance_company_id ?? ''}
+                        onChange={e => handleFieldChange(index, 'insurance_company_id', Number(e.target.value))}
+                        sx={{
+                          fontSize: '0.75rem',
+                          '& .MuiSelect-select': {
+                            p: '4px 8px'
+                          }
+                        }}
+                      >
+                        {insuranceCompanies.map(company => (
+                          <MenuItem key={company.id} value={company.id}>
+                            {company.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.percentage}
+                      onChange={e => handleFieldChange(index, 'percentage', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0', max: '1' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.sum_insured}
+                      onChange={e => handleFieldChange(index, 'sum_insured', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.retention_percentage}
+                      onChange={e => handleFieldChange(index, 'retention_percentage', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0', max: '1' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.premium}
+                      onChange={e => handleFieldChange(index, 'premium', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.commission}
+                      onChange={e => handleFieldChange(index, 'commission', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='number'
+                      value={entry.bonus}
+                      onChange={e => handleFieldChange(index, 'bonus', e.target.value)}
+                      size='small'
+                      inputProps={{ step: '0.01', min: '0' }}
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px',
+                          textAlign: 'right'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='text'
+                      value={entry.receipt_number}
+                      onChange={e => handleFieldChange(index, 'receipt_number', e.target.value)}
+                      size='small'
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='date'
+                      value={entry.premium_payment_date}
+                      onChange={e => handleFieldChange(index, 'premium_payment_date', e.target.value)}
+                      size='small'
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='date'
+                      value={entry.commission_payment_date || ''}
+                      onChange={e => handleFieldChange(index, 'commission_payment_date', e.target.value || null)}
+                      size='small'
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <TextField
+                      type='date'
+                      value={entry.bonus_payment_date || ''}
+                      onChange={e => handleFieldChange(index, 'bonus_payment_date', e.target.value || null)}
+                      size='small'
+                      sx={{
+                        width: '100%',
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.75rem',
+                          p: '4px 8px'
+                        }
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell align='center' sx={{ p: 0.5 }}>
+                    <Tooltip title='Eliminar aseguradora'>
+                      <IconButton
+                        onClick={() => handleDeleteInsurer(index)}
+                        color='error'
+                        size='small'
+                        disabled={entries.length === 1}
+                      >
+                        <DeleteIcon fontSize='small' />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {/* Botón para añadir aseguradora */}
+      {entries.length > 0 && (
+        <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-start' }}>
+          <Button variant='outlined' startIcon={<AddIcon />} onClick={handleAddInsurer} size='small'>
+            Añadir Aseguradora
+          </Button>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default CoInsuranceTable
+export type { CoInsuranceEntry }

--- a/src/app/(dashboard)/policies/create/page.tsx
+++ b/src/app/(dashboard)/policies/create/page.tsx
@@ -559,7 +559,20 @@ export default function PolicyForm() {
               />
             </Grid>
           </Grid>
-
+          <Grid item xs={12} md={3}>
+            <Controller
+              name='has_co_insurance'
+              control={control}
+              render={({ field }) => (
+                <FormControl component='fieldset'>
+                  <FormControlLabel
+                    control={<Switch checked={!!field.value} onChange={e => field.onChange(e.target.checked)} />}
+                    label='¿Tiene coaseguro?'
+                  />
+                </FormControl>
+              )}
+            />
+          </Grid>
           {/* Mostrar InstallmentPlan cuando el modo de pago sea 'Fraccionado' */}
           {paymentMode === 'I' && (
             <InstallmentPlan onCalculate={handleInstallmentCalculate} effectiveDate={effectiveDate} />

--- a/src/app/(dashboard)/policies/create/page.tsx
+++ b/src/app/(dashboard)/policies/create/page.tsx
@@ -37,6 +37,7 @@ import { ClientAutocomplete } from './components/ClientAutocomplete'
 import { VehicleAutocomplete } from './components/VehicleAutocomplete'
 import VehicleModal from './components/VehicleModal'
 import InstallmentPlan from './components/InstallmentPlan'
+import CoInsuranceTable, { type CoInsuranceEntry } from './components/CoInsuranceTable'
 
 const POLICY_PERIOD_OPTIONS = [
   { value: 1, label: 'Mensual' },
@@ -55,6 +56,7 @@ export default function PolicyForm() {
   const [isHolderDifferent, setIsHolderDifferent] = React.useState(false)
   const [isVehicleModalOpen, setIsVehicleModalOpen] = React.useState(false)
   const [installmentPlanData, setInstallmentPlanData] = React.useState<InstallmentPlanData | null>(null)
+  const [coInsuranceEntries, setCoInsuranceEntries] = React.useState<CoInsuranceEntry[]>([])
   const { lines: insuranceLines, loading: linesLoading, error: linesError } = useInsuranceLines()
   const { companies: insuranceCompanies, loading: companiesLoading, error: companiesError } = useInsuranceCompanies()
   const { collectors, loading: collectorsLoading, error: collectorsError } = useCollectors()
@@ -94,6 +96,7 @@ export default function PolicyForm() {
   const holderId = watch('holder_id')
   const lineId = watch('line_id')
   const paymentMode = watch('payment_mode')
+  const hasCoInsurance = watch('has_co_insurance')
 
   const policyPeriod = watch('policy_period')
 
@@ -147,6 +150,11 @@ export default function PolicyForm() {
     if (paymentMode !== 'I') {
       setInstallmentPlanData(null)
     }
+
+    // Limpiar datos de coaseguro si se desactiva
+    if (!hasCoInsurance) {
+      setCoInsuranceEntries([])
+    }
   }, [effectiveDate, policyPeriod, setValue, isHolderDifferent, holderId, shouldShowVehicle, paymentMode])
 
   const onSubmit = async (data: PolicyFormInputs) => {
@@ -187,7 +195,7 @@ export default function PolicyForm() {
     }
 
     if (data.has_co_insurance) {
-      payload.co_insurance_entries = []
+      payload.co_insurance_entries = coInsuranceEntries
     }
 
     try {
@@ -573,9 +581,15 @@ export default function PolicyForm() {
               )}
             />
           </Grid>
+
           {/* Mostrar InstallmentPlan cuando el modo de pago sea 'Fraccionado' */}
           {paymentMode === 'I' && (
             <InstallmentPlan onCalculate={handleInstallmentCalculate} effectiveDate={effectiveDate} />
+          )}
+
+          {/* Mostrar CoInsuranceTable cuando tiene coaseguro */}
+          {hasCoInsurance && (
+            <CoInsuranceTable insuranceCompanies={insuranceCompanies} onEntriesChange={setCoInsuranceEntries} />
           )}
 
           <Box mt={3}>

--- a/src/app/(dashboard)/policies/create/page.tsx
+++ b/src/app/(dashboard)/policies/create/page.tsx
@@ -195,7 +195,21 @@ export default function PolicyForm() {
     }
 
     if (data.has_co_insurance) {
-      payload.co_insurance_entries = coInsuranceEntries
+      payload.co_insurance_entries = coInsuranceEntries.map(entry => ({
+        insurance_company_id: entry.insurance_company_id,
+
+        // Convertir porcentajes de 0-100 a decimal con 4 decimales
+        percentage: ((parseFloat(entry.percentage) || 0) / 100).toFixed(4),
+        sum_insured: parseFloat(entry.sum_insured || '0').toFixed(2),
+        retention_percentage: ((parseFloat(entry.retention_percentage) || 0) / 100).toFixed(4),
+        premium: parseFloat(entry.premium || '0').toFixed(2),
+        commission: parseFloat(entry.commission || '0').toFixed(2),
+        bonus: parseFloat(entry.bonus || '0').toFixed(2),
+        receipt_number: entry.receipt_number || '',
+        premium_payment_date: entry.premium_payment_date || null,
+        commission_payment_date: entry.commission_payment_date || null,
+        bonus_payment_date: entry.bonus_payment_date || null
+      }))
     }
 
     try {


### PR DESCRIPTION
This pull request enhances the policy creation form by adding full support for co-insurance entries. It introduces a new UI component for managing co-insurance details, ensures proper state management, and processes co-insurance data for submission. The main changes are grouped below:

**Co-insurance feature integration:**

* Added the `CoInsuranceTable` component to the form, allowing users to input and manage multiple co-insurance entries. (`src/app/(dashboard)/policies/create/page.tsx`) [[1]](diffhunk://#diff-95c8f809428418364a16af540812bab02bb55c822f82e72971c18e3f2f521e9dR40) [[2]](diffhunk://#diff-95c8f809428418364a16af540812bab02bb55c822f82e72971c18e3f2f521e9dR584-R608)
* Introduced the `has_co_insurance` switch to enable or disable co-insurance, and a corresponding state (`coInsuranceEntries`) to track the entries. (`src/app/(dashboard)/policies/create/page.tsx`) [[1]](diffhunk://#diff-95c8f809428418364a16af540812bab02bb55c822f82e72971c18e3f2f521e9dR59) [[2]](diffhunk://#diff-95c8f809428418364a16af540812bab02bb55c822f82e72971c18e3f2f521e9dR584-R608)

**State and data handling improvements:**

* Automatically clears co-insurance entries when the co-insurance option is turned off, preventing stale data from being submitted. (`src/app/(dashboard)/policies/create/page.tsx`)
* On form submission, maps and formats co-insurance entry data (e.g., converting percentages to decimals and formatting numbers) before including it in the payload. (`src/app/(dashboard)/policies/create/page.tsx`)
* Watches the `has_co_insurance` field for changes to ensure UI and state remain in sync. (`src/app/(dashboard)/policies/create/page.tsx`)